### PR TITLE
Format `errors.py` with black

### DIFF
--- a/linkedin_api/clients/restli/utils/api.py
+++ b/linkedin_api/clients/restli/utils/api.py
@@ -1,9 +1,16 @@
 import linkedin_api.common.constants as constants
-from importlib.metadata import version
 from linkedin_api.clients.restli.utils.encoder import encode
 from typing import Dict, Any, Optional
 from linkedin_api.common.errors import InvalidArgumentError
 import re
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
+
 
 __version__ = version("linkedin-api-client")
 

--- a/linkedin_api/common/errors.py
+++ b/linkedin_api/common/errors.py
@@ -12,6 +12,7 @@ class ResponseFormattingError(Exception):
     "Error raised when formatting API response"
     pass
 
+
 class InvalidSerializedRestliError(Exception):
     "Error raised when an incorrectly serialized Rest.li string is encountered"
     pass

--- a/tests/clients/restli/client_test.py
+++ b/tests/clients/restli/client_test.py
@@ -1,6 +1,5 @@
 import json
 from linkedin_api.clients.restli.client import RestliClient
-from importlib.metadata import version
 import pytest
 import responses
 from responses import matchers
@@ -11,6 +10,12 @@ from linkedin_api.common.constants import (
     VERSIONED_BASE_URL,
     HTTP_METHODS,
 )
+import sys
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
 __version__ = version("linkedin-api-client")
 ACCESS_TOKEN = "ABC123"


### PR DESCRIPTION
If you run `poetry run pre-commit run --all-files `, you will get an error because `linkedin_api/common/errors.py` is not formatted correctly. This PR fixes that issue.