### PR TITLE
Use `None` instead of `{}` for default arguments and fix some other small issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 venv/
 .vscode
 .DS_Store
+.idea

--- a/linkedin_api/clients/restli/client.py
+++ b/linkedin_api/clients/restli/client.py
@@ -1,7 +1,6 @@
 import requests
 import copy
 from typing import Union, Dict, Any, List, Optional, Type, Tuple, TypeVar
-from linkedin_api.clients.common.response import BaseResponse
 import linkedin_api.clients.restli.utils.api as apiutils
 import linkedin_api.clients.restli.utils.encoder as encoder
 from linkedin_api.clients.restli.utils.restli import (
@@ -67,7 +66,7 @@ class RestliClient:
         resource_path: str,
         access_token: str,
         path_keys: Optional[Dict[str, Any]] = None,
-        query_params: Optional[Dict[str, Any]] = {},
+        query_params: Optional[Dict[str, Any]] = None,
         version_string: Optional[str] = None
     ) -> GetResponse:
         """
@@ -508,7 +507,7 @@ class RestliClient:
         ids: List[RestliEntityId],
         access_token: str,
         path_keys: Optional[Dict[str, Any]] = None,
-        query_params: Optional[Dict[str, Any]] = {},
+        query_params: Optional[Dict[str, Any]] = None,
         version_string: Optional[str] = None
     ) -> BatchUpdateResponse:
         """
@@ -689,7 +688,7 @@ class RestliClient:
         resource_path: str,
         access_token: str,
         path_keys: Optional[Dict[str, Any]] = None,
-        query_params: Optional[Dict[str, Any]] = {},
+        query_params: Optional[Dict[str, Any]] = None,
         version_string: Optional[str] = None
     ) -> BaseRestliResponse:
         """
@@ -734,7 +733,7 @@ class RestliClient:
         ids: List[RestliEntityId],
         access_token: str,
         path_keys: Optional[Dict[str, Any]] = None,
-        query_params: Optional[Dict[str, Any]] = {},
+        query_params: Optional[Dict[str, Any]] = None,
         version_string: Optional[str] = None
     ) -> BatchDeleteResponse:
         """

--- a/linkedin_api/clients/restli/response_formatter.py
+++ b/linkedin_api/clients/restli/response_formatter.py
@@ -1,8 +1,27 @@
+from typing import Dict
+
 from linkedin_api.clients.common.response_formatter import (
     BaseResponseFormatter,
     wrap_format_exception,
 )
-from linkedin_api.clients.restli.response import *
+from linkedin_api.clients.restli.response import (
+    GetResponse,
+    BatchGetResponse,
+    CollectionResponse,
+    Paging,
+    BatchFinderResponse,
+    BatchFinderResult,
+    CreateResponse,
+    BatchCreateResponse,
+    BatchCreateResult,
+    UpdateResponse,
+    BatchUpdateResponse,
+    BatchUpdateResult,
+    BaseRestliResponse,
+    BatchDeleteResponse,
+    BatchDeleteResult,
+    ActionResponse,
+)
 from linkedin_api.clients.restli.utils.restli import get_created_entity_id
 from requests import Response
 

--- a/linkedin_api/clients/restli/utils/api.py
+++ b/linkedin_api/clients/restli/utils/api.py
@@ -76,7 +76,7 @@ def build_rest_url(
         base_url = constants.NON_VERSIONED_BASE_URL
 
     # Validate resource_path and path_keys
-    num_path_keys = 0 if path_keys == None else len(path_keys.keys())
+    num_path_keys = 0 if path_keys is None else len(path_keys.keys())
     if path_keys:
         encoded_path_keys = {k: encode(v) for (k, v) in path_keys.items()}
     else:

--- a/linkedin_api/clients/restli/utils/decoder.py
+++ b/linkedin_api/clients/restli/utils/decoder.py
@@ -187,7 +187,7 @@ def __decode_object(restli_encoded_str: str, reduced: bool) -> Dict[str, Any]:
     decoded_object = {}
     idx = 0
     while idx < len(restli_encoded_str):
-        # Get the key value between the start index and key-val separater (:)
+        # Get the key value between the start index and key-val separator (:)
         colon_idx = restli_encoded_str.find(OBJ_KEY_VAL_SEP, idx)
         key = __restli_unescape(restli_encoded_str[idx:colon_idx], reduced)
 

--- a/linkedin_api/clients/restli/utils/query_tunneling.py
+++ b/linkedin_api/clients/restli/utils/query_tunneling.py
@@ -10,7 +10,7 @@ import linkedin_api.clients.restli.utils.api as apiutils
 import random
 import string
 import json
-from typing import Optional, Type
+from typing import Optional
 
 MAX_QUERY_STRING_LENGTH = 4000
 

--- a/linkedin_api/common/errors.py
+++ b/linkedin_api/common/errors.py
@@ -1,18 +1,14 @@
 class InvalidArgumentError(Exception):
-    "Error raised for invalid arguments"
-    pass
+    """Error raised for invalid arguments"""
 
 
 class MissingArgumentError(Exception):
-    "Error raised for missing arguments"
-    pass
+    """Error raised for missing arguments"""
 
 
 class ResponseFormattingError(Exception):
-    "Error raised when formatting API response"
-    pass
+    """Error raised when formatting API response"""
 
 
 class InvalidSerializedRestliError(Exception):
-    "Error raised when an incorrectly serialized Rest.li string is encountered"
-    pass
+    """Error raised when an incorrectly serialized Rest.li string is encountered"""


### PR DESCRIPTION
Closes #28

I think I replaced all default values `{}` with `None` (where this was opportune), but maybe you can double check that I didn't miss anything.

I've also fixed a few other small issues