### PR TITLE
Updated examples `get_profile` and `create_posts` in line with new API

### DIFF
--- a/examples/create_posts.py
+++ b/examples/create_posts.py
@@ -28,7 +28,7 @@ if ACCESS_TOKEN is None:
         'A valid access token must be defined in the /examples/.env file under the variable name "ACCESS_TOKEN"'
     )
 
-ME_RESOURCE = "/me"
+ME_RESOURCE = "/userinfo"
 UGC_POSTS_RESOURCE = "/ugcPosts"
 POSTS_RESOURCE = "/posts"
 API_VERSION = "202302"
@@ -49,7 +49,7 @@ Calling the legacy /ugcPosts API to create a text post on behalf of the authenti
 ugc_posts_create_response = restli_client.create(
     resource_path=UGC_POSTS_RESOURCE,
     entity={
-        "author": f"urn:li:person:{me_response.entity['id']}",
+        "author": f"urn:li:person:{me_response.entity['sub']}",
         "lifecycleState": "PUBLISHED",
         "specificContent": {
             "com.linkedin.ugc.ShareContent": {
@@ -75,7 +75,7 @@ of the authenticated member
 posts_create_response = restli_client.create(
     resource_path=POSTS_RESOURCE,
     entity={
-        "author": f"urn:li:person:{me_response.entity['id']}",
+        "author": f"urn:li:person:{me_response.entity['sub']}",
         "lifecycleState": "PUBLISHED",
         "visibility": "PUBLIC",
         "commentary": "Sample text post created with /posts API",

--- a/examples/get_profile.py
+++ b/examples/get_profile.py
@@ -21,34 +21,40 @@ if ACCESS_TOKEN is None:
         'A valid access token must be defined in the /examples/.env file under the variable name "ACCESS_TOKEN"'
     )
 
-PROFILE_RESOURCE = "/me"
+PROFILE_RESOURCE = "/userinfo"
 
 restli_client = RestliClient()
 
 """
 Basic usage to fetch current member profile
 """
-response = restli_client.get(resource_path=PROFILE_RESOURCE, access_token=ACCESS_TOKEN)
-print("Basic usage:", response.entity)
+response_basic = restli_client.get(
+    resource_path=PROFILE_RESOURCE, access_token=ACCESS_TOKEN
+)
+print("Basic usage:", response_basic.entity)
+
 
 """
 Usage with field projections
 """
-response = restli_client.get(
+response_field_projects = restli_client.get(
     resource_path=PROFILE_RESOURCE,
     access_token=ACCESS_TOKEN,
-    query_params={"fields": "id,firstName:(localized),lastName"},
+    query_params={
+        "fields": "sub,email_verified,name,locale,given_name,family_name,email,picture"
+    },
 )
-print("\n\nUsage with field projections:", response.entity)
+print("\n\nUsage with field projections:", response_field_projects.entity)
 
 """
 Usage with decoration of displayImage
 """
-response = restli_client.get(
+
+response_display_image = restli_client.get(
     resource_path=PROFILE_RESOURCE,
     access_token=ACCESS_TOKEN,
     query_params={
-        "projection": "(id,firstName,lastName,profilePicture(displayImage~:playableStreams))"
+        "projection": "(sub,given_name,family_name,picture(displayImage~:playableStreams))"
     },
 )
-print("\n\nUsage with decoration:", response.entity)
+print("\n\nUsage with decoration:", response_display_image.entity)


### PR DESCRIPTION
The current examples use the `/me` endpoint and try to identify the profile by the following URN string:
`f"urn:li:person:{me_response.entity['id']}`.

However, I found that even though I have a valid 3-legged-token with the necessary scopes enabled, I was getting an error.

I believe that the most recent changes to the LinkedIn API require the following changes:

1. `/userinfo` GET endpoint instead of `/me`
2. `me_response.entity['sub']` instead of `me_response.entity['id']`

There are some further differences in the names of the fields returned by the `userinfo` and `me` endpoints, which are reflected in the proposed changes in the example `get_profile.py`.